### PR TITLE
removed singleton comparison pitfall from the code

### DIFF
--- a/spaceship_generator.py
+++ b/spaceship_generator.py
@@ -42,7 +42,7 @@ def reset_scene():
 # with all the additional side faces created from the extrusion.
 def extrude_face(bm, face, translate_forwards=0.0, extruded_face_list=None):
     new_faces = bmesh.ops.extrude_discrete_faces(bm, faces=[face])['faces']
-    if extruded_face_list != None:
+    if extruded_face_list is not None:
         extruded_face_list += new_faces[:]
     new_face = new_faces[0]
     bmesh.ops.translate(bm,


### PR DESCRIPTION
**The problem**
In Python when comparing a variable to a singleton value like True, False and None it is advised to use the operator 'is' instead of '=='. This pitfall was detected using Pylint, which indicated it under the code C0121, as seen on the link below
https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0121.html

**The solution**
Just changed the operator